### PR TITLE
Update README.md: Versionen der Dependencies aktualisiert

### DIFF
--- a/HelloJexxa/README.md
+++ b/HelloJexxa/README.md
@@ -29,13 +29,13 @@
        <dependency>
           <groupId>io.jexxa</groupId>
           <artifactId>jexxa-web</artifactId>
-          <version>5.7.0</version>
+          <version>6.1.4</version>
        </dependency>
        
        <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-simple</artifactId>
-           <version>2.0.6</version>
+           <version>2.0.7</version>
        </dependency>
    </dependencies>
 </project>


### PR DESCRIPTION
In Version 5.7.0 von Jexxa-Web gibt es keine Klasse "io.jexxa.drivingadapter.rest.RESTfulRPCAdapter", wodurch das korrekte Ausführen der Anweisungen zu einem Compiler-Fehler führt. Um das zu korrigieren wurde Jexxa-Web zu Version 6.1.4 aktualisiert. SLF4J wurde zusätzlich zu Version 2.0.7 aktualisiert